### PR TITLE
Fix local storage caching for catalog items

### DIFF
--- a/src/BlazorAdmin/Services/CachedCatalogItemServiceDecorator.cs
+++ b/src/BlazorAdmin/Services/CachedCatalogItemServiceDecorator.cs
@@ -74,7 +74,7 @@ public class CachedCatalogItemServiceDecorator : ICatalogItemService
 
     public async Task<CatalogItem> GetById(int id)
     {
-        return (await List()).FirstOrDefault(x => x.Id == id);
+        return (await ListPaged(10)).FirstOrDefault(x => x.Id == id);
     }
 
     public async Task<CatalogItem> Create(CreateCatalogItemRequest catalogItem)


### PR DESCRIPTION
The local storage in BlazorAdmin was trying to retrieve a catalog item from the unpaged list of items, which would not be present if the item was on a later page of results. This change updates the `GetById` method to retrieve the item from the paged list, which will always contain the item regardless of its page.