### PR TITLE
Fix issue with GetById catalog item

### DIFF
--- a/src/BlazorAdmin/Services/CachedCatalogItemServiceDecorator.cs
+++ b/src/BlazorAdmin/Services/CachedCatalogItemServiceDecorator.cs
@@ -74,7 +74,7 @@ public class CachedCatalogItemServiceDecorator : ICatalogItemService
 
     public async Task<CatalogItem> GetById(int id)
     {
-        return (await List()).FirstOrDefault(x => x.Id == id);
+        return (await ListPaged(10)).FirstOrDefault(x => x.Id == id);
     }
 
     public async Task<CatalogItem> Create(CreateCatalogItemRequest catalogItem)


### PR DESCRIPTION
The `GetById` method in `CachedCatalogItemServiceDecorator` was using the `List` method, this method do not use a pagination. So it download all items. 
The fix is to use the `ListPaged` method instead.