### PR TITLE
Fix local storage cache in admin

### DIFF
--- a/src/BlazorAdmin/Services/CachedCatalogItemServiceDecorator.cs
+++ b/src/BlazorAdmin/Services/CachedCatalogItemServiceDecorator.cs
@@ -74,7 +74,7 @@ public class CachedCatalogItemServiceDecorator : ICatalogItemService
 
     public async Task<CatalogItem> GetById(int id)
     {
-        return (await List()).FirstOrDefault(x => x.Id == id);
+        return (await ListPaged(10)).FirstOrDefault(x => x.Id == id);
     }
 
     public async Task<CatalogItem> Create(CreateCatalogItemRequest catalogItem)


### PR DESCRIPTION
The GetById method in the CachedCatalogItemServiceDecorator class was incorrectly using the List method to get a CatalogItem by Id. This would result in a cache miss even if the item was already in the local storage cache.

This commit fixes the issue by using the ListPaged method instead, which will check the local storage cache before making a request to the API.