### PR TITLE
Fix pagination in blazor admin

### DIFF
--- a/src/BlazorAdmin/Services/CatalogItemService.cs
+++ b/src/BlazorAdmin/Services/CatalogItemService.cs
@@ -62,7 +62,7 @@ public class CatalogItemService : ICatalogItemService
 
         var brandListTask = _brandService.List();
         var typeListTask = _typeService.List();
-        var itemListTask = _httpService.HttpGet<PagedCatalogItemResponse>($"catalog-items?PageSize=10");
+        var itemListTask = _httpService.HttpGet<PagedCatalogItemResponse>($"catalog-items?pageSize={pageSize}");
         await Task.WhenAll(brandListTask, typeListTask, itemListTask);
         var brands = brandListTask.Result;
         var types = typeListTask.Result;


### PR DESCRIPTION
The page size was hardcoded to 10. This is now fixed by using the given page size.