### PR TITLE
Fix bug in CachedCatalogItemServiceDecorator

### DIFF
--- a/src/BlazorAdmin/Services/CachedCatalogItemServiceDecorator.cs
+++ b/src/BlazorAdmin/Services/CachedCatalogItemServiceDecorator.cs
@@ -74,7 +74,7 @@ public class CachedCatalogItemServiceDecorator : ICatalogItemService
 
     public async Task<CatalogItem> GetById(int id)
     {
-        return (await List()).FirstOrDefault(x => x.Id == id);
+        return (await _catalogItemService.List()).FirstOrDefault(x => x.Id == id);
     }
 
     public async Task<CatalogItem> Create(CreateCatalogItemRequest catalogItem)


### PR DESCRIPTION
The GetById method in CachedCatalogItemServiceDecorator was not using the injected _catalogItemService to retrieve the list of items, resulting in a null reference exception. This commit fixes the bug by using _catalogItemService.List() to get the items.